### PR TITLE
fix: add supports for vllm v0.19

### DIFF
--- a/qwen2_5_coder_tool_parser.py
+++ b/qwen2_5_coder_tool_parser.py
@@ -65,8 +65,8 @@ class Qwen25CoderToolParser(ToolParser):
     Not applicable to Qwen2.5 (non-Coder) which uses hermes natively.
     """
 
-    def __init__(self, tokenizer: AnyTokenizer):
-        super().__init__(tokenizer)
+    def __init__(self, tokenizer: AnyTokenizer, tools=None):
+        super().__init__(tokenizer, tools)
 
         # <tools> tag tokens
         self.tool_call_start_token: str = "<tools>"


### PR DESCRIPTION
Modified the constructor to accept an optional 'tools' parameter.